### PR TITLE
Lower lambdalith memory limit

### DIFF
--- a/stacks/control_broker_stack.py
+++ b/stacks/control_broker_stack.py
@@ -1100,7 +1100,7 @@ class ControlBrokerStack(Stack, SecretConfigStackMixin):
             runtime=aws_lambda.Runtime.PYTHON_3_9,
             handler="lambda_function.lambda_handler",
             timeout=Duration.seconds(60),
-            memory_size=10240, # TODO power-tune
+            memory_size=3008, # TODO power-tune
             code=aws_lambda.Code.from_asset(
                 "./supplementary_files/lambdas/eval_engine_lambdalith"
             ),


### PR DESCRIPTION
Fixes https://github.com/VerticalRelevance/control-broker/issues/27.

3008 is the effective max in some regions.

Prior to this change, I was unable to deploy Control Broker in us-west-1 and us-west-2. See https://github.com/VerticalRelevance/control-broker/issues/27 for a likely explanation.

After making this change, I was able to deploy Control Broker in us-west-2.